### PR TITLE
Ansible pass

### DIFF
--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -15,10 +15,6 @@ webportals_prod
 # [webportals:vars] label.
 [webportals:vars]
 
-
-ansible_become_pass="{{ lookup('community.general.lastpass', webportal_user + '@' + ansible_host, field='password') if (lastpass_required|default(False)) else None}}"
-webportal_user_pass_hash="{{ ansible_become_pass | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
-
 # ansible_become_pass is required to execute playbooks without root access
 # using (become=True). It is Ansible internal variable and it is not lazy
 # evaluated as user defined variables. We need to set default value for

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -15,13 +15,26 @@ webportals_prod
 # [webportals:vars] label.
 [webportals:vars]
 
+
+ansible_become_pass="{{ lookup('community.general.lastpass', webportal_user + '@' + ansible_host, field='password') if (lastpass_required|default(False)) else None}}"
+webportal_user_pass_hash="{{ ansible_become_pass | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
+
 # ansible_become_pass is required to execute playbooks without root access
 # using (become=True). It is Ansible internal variable and it is not lazy
 # evaluated as user defined variables. We need to set default value for
-# playbooks not requiring this var and not having active LastPass session.
+# playbooks not requiring this var and not having active LastPass session. For
+# portal-setup-initial we allow this password to be missing and we create it in
+# LastPass (if missing).
+#
+# Condition:
+# Check for user password if (LastPass is required and not (allow missing password and password is missing))
+#
+# lastpass_required|default(False): Ask for LastPass password when requied
+# lastpass_allow_missing_user_credentials|default(False): Flag to allow for missing LastPass password
+# lookup('pipe', 'lpass ls ' + lastpass_portal_credentials_server) == '': Password is missing in LastPass
 # 
 # ***DO NOT EDIT***
-ansible_become_pass="{{ lookup('community.general.lastpass', webportal_user + '@' + ansible_host, field='password') if (lastpass_required|default(False)) else None}}"
+ansible_become_pass="{{ lookup('community.general.lastpass', webportal_user + '@' + ansible_host, field='password') if (lastpass_required|default(False) and not (lastpass_allow_missing_user_credentials|default(False) and lookup('pipe', 'lpass ls ' + lastpass_portal_credentials_server) == '')) else '' }}"
 webportal_user_pass_hash="{{ ansible_become_pass | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
 
 # Define servers that make up the child groups.


### PR DESCRIPTION
# PULL REQUEST

## Overview

Update `ansible_become_pass` so that ansible playbooks (`portal-setup-initial` ev. `portal-setup-following`) can autogenerate `user` user OS password and store it in LastPass.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
